### PR TITLE
Feature/add attribute for composition for single routes

### DIFF
--- a/src/Mozart.Composition.AspNetCore.Mvc.UnitTests/Actions/Filters/MozartComposeModelAttributeShould.cs
+++ b/src/Mozart.Composition.AspNetCore.Mvc.UnitTests/Actions/Filters/MozartComposeModelAttributeShould.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using Moq;
+using Mozart.Composition.AspNetCore.Mvc.Actions.Filters;
+using Mozart.Composition.AspNetCore.Mvc.Results.Abstractions;
+using Mozart.Composition.Core.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Mozart.Composition.AspNetCore.Mvc.UnitTests.Actions.Filters
+{
+    public class MozartComposeModelAttributeShould
+    {
+        private readonly MozartComposeModelAttribute _mozartComposeModelAttribute;
+
+        public MozartComposeModelAttributeShould()
+        {
+            _mozartComposeModelAttribute = new MozartComposeModelAttribute();
+        }
+
+        [Fact]
+        public void ThrowAnArgumentNullExceptionIfNullServiceProviderIsPassedWhenCreatingViaMvcPipeline()
+        {            
+            Should.Throw<ArgumentNullException>(() =>
+                _mozartComposeModelAttribute.CreateInstance(null));
+        }
+
+        [Fact]
+        public void ThrowAnArgumentNullExceptionIfICachedServiceResolverIsNotRegisteredInServiceProviderWhenCreatingViaMvcPipeline()
+        {
+            // Arrange
+            var mockServiceProvider = new Mock<IServiceProvider>();
+
+            // Act / Assert
+            Should.Throw<ArgumentNullException>(() =>
+                _mozartComposeModelAttribute.CreateInstance(mockServiceProvider.Object));
+        }
+
+        [Fact]
+        public void UseServiceCollectionToResolveTheCachedServiceResolverWhenCreatingViaMvcPipeline()
+        {
+            // Arrange
+            var mockServiceProvider = new Mock<IServiceProvider>();
+            var cachedServiceResolverMock = new Mock<ICachedServiceResolver<string, IHandleResult>>();
+            mockServiceProvider.Setup(x => x.GetService(typeof(ICachedServiceResolver<string, IHandleResult>)))
+                .Returns(cachedServiceResolverMock.Object);
+
+            // Act
+            _mozartComposeModelAttribute.CreateInstance(mockServiceProvider.Object);
+
+            // Assert
+            mockServiceProvider.Verify(x => x.GetService(typeof(ICachedServiceResolver<string, IHandleResult>)), Times.Once);
+        }
+
+        [Fact]
+        public void ReturnAnInstanceOfCompositionResultActionFilterWhenCreatingViaMvcPipeline()
+        {
+            // Arrange
+            var mockServiceProvider = new Mock<IServiceProvider>();
+            var cachedServiceResolverMock = new Mock<ICachedServiceResolver<string, IHandleResult>>();
+            mockServiceProvider.Setup(x => x.GetService(typeof(ICachedServiceResolver<string, IHandleResult>)))
+                .Returns(cachedServiceResolverMock.Object);
+
+            // Act
+            var result = _mozartComposeModelAttribute.CreateInstance(mockServiceProvider.Object);
+
+            // Assert
+            result.ShouldBeOfType<CompositionResultActionFilter>();
+        }
+
+        [Fact]
+        public void BeReusable()
+        {
+            _mozartComposeModelAttribute.IsReusable.ShouldBeTrue();
+        }
+    }
+}

--- a/src/Mozart.Composition.AspNetCore.Mvc/Actions/Filters/CompositionResultActionFilter.cs
+++ b/src/Mozart.Composition.AspNetCore.Mvc/Actions/Filters/CompositionResultActionFilter.cs
@@ -12,7 +12,7 @@ namespace Mozart.Composition.AspNetCore.Mvc.Actions.Filters
     {
         private readonly ICachedServiceResolver<string, IHandleResult> _resultHandlerResolver;
 
-        public CompositionResultActionFilter(ICachedServiceResolver<string, IHandleResult> resultHandlerResolver)
+        internal CompositionResultActionFilter(ICachedServiceResolver<string, IHandleResult> resultHandlerResolver)
         {
             _resultHandlerResolver = resultHandlerResolver;        
         }

--- a/src/Mozart.Composition.AspNetCore.Mvc/Actions/Filters/MozartComposeModelAttribute.cs
+++ b/src/Mozart.Composition.AspNetCore.Mvc/Actions/Filters/MozartComposeModelAttribute.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+using Mozart.Composition.AspNetCore.Mvc.Results.Abstractions;
+using Mozart.Composition.Core.Abstractions;
+
+namespace Mozart.Composition.AspNetCore.Mvc.Actions.Filters
+{
+    ///  <inheritdoc cref="Attribute" />
+    ///  <summary>
+    ///  Tell Mozart to intercept the result for this action and auto compose based on the declared type.
+    ///  Requires resolved services so you should make use of <see cref="TypeFilterAttribute"/> or <seealso cref="ServiceFilterAttribute"/>.
+    ///  </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public class MozartComposeModelAttribute : Attribute, IFilterFactory
+    {
+        
+        public IFilterMetadata CreateInstance(IServiceProvider serviceProvider)
+        {
+            var cachedServiceResolver = serviceProvider.GetService<ICachedServiceResolver<string, IHandleResult>>();
+            if (cachedServiceResolver == null)
+            {
+                throw new ArgumentNullException(
+                    $"{nameof(ICachedServiceResolver<string, IHandleResult>)} not present in service provider.");
+            }
+            return new CompositionResultActionFilter(cachedServiceResolver);
+        }
+
+        public bool IsReusable => true; 
+    }
+}

--- a/src/Mozart.Composition.AspNetCore.Mvc/Actions/Filters/MozartComposeModelAttribute.cs
+++ b/src/Mozart.Composition.AspNetCore.Mvc/Actions/Filters/MozartComposeModelAttribute.cs
@@ -12,12 +12,15 @@ namespace Mozart.Composition.AspNetCore.Mvc.Actions.Filters
     ///  Tell Mozart to intercept the result for this action and auto compose based on the declared type.
     ///  Requires resolved services so you should make use of <see cref="TypeFilterAttribute"/> or <seealso cref="ServiceFilterAttribute"/>.
     ///  </summary>
-    [AttributeUsage(AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
     public class MozartComposeModelAttribute : Attribute, IFilterFactory
-    {
-        
+    {        
         public IFilterMetadata CreateInstance(IServiceProvider serviceProvider)
         {
+            if (serviceProvider == null)
+            {
+                throw new ArgumentNullException($"{nameof(serviceProvider)}");
+            }
             var cachedServiceResolver = serviceProvider.GetService<ICachedServiceResolver<string, IHandleResult>>();
             if (cachedServiceResolver == null)
             {

--- a/src/Mozart.Composition.AspNetCore.Mvc/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Mozart.Composition.AspNetCore.Mvc/DependencyInjection/ServiceCollectionExtensions.cs
@@ -48,13 +48,13 @@ namespace Mozart.Composition.AspNetCore.Mvc.DependencyInjection
 
             RegisterActionReturnTypeStrategyServices(serviceCollection);
 
-            // The result filter that orchestrates the composition of the result
-            serviceCollection.Configure<MvcOptions>(options =>
-            {
-                options.Filters.Add<CompositionResultActionFilter>();
-            });
-
             return serviceCollection;
+        }
+
+        public static void AddMozartModelCompositionGlobally(this IServiceCollection serviceCollection)
+        {
+            // The result filter that orchestrates the composition of the result
+            serviceCollection.Configure<MvcOptions>(options => { options.Filters.Add<CompositionResultActionFilter>(); });
         }
 
         private static void RegisterResultHandlerResolver(IServiceCollection serviceCollection)

--- a/src/Mozart.Composition.Core/Mozart.Composition.Core.csproj
+++ b/src/Mozart.Composition.Core/Mozart.Composition.Core.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="Mozart.Composition.Core.csproj.DotSettings" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />


### PR DESCRIPTION
Don't enforce the use of Model Composition globally and provide an attribute to allow route by route or controller by controller