### PR TITLE
Remove global filter and only cache action result resolvers for the actions marked with MozartComposeModel

### DIFF
--- a/demo/Mozart.Composition.AspNetCore.Mvc.Demo/Startup.cs
+++ b/demo/Mozart.Composition.AspNetCore.Mvc.Demo/Startup.cs
@@ -21,10 +21,8 @@ namespace Mozart.Composition.AspNetCore.Mvc.Demo
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc();
-            
+            services.AddMvc();            
             services.AddMozartMvcComposition();
-
             services.AddDependentServicesForModelComposition(Configuration);            
         }
 

--- a/src/Mozart.Composition.AspNetCore.Mvc/Actions/Predicates/ControllerActionDescriptorHttpGetPredicateWrapper.cs
+++ b/src/Mozart.Composition.AspNetCore.Mvc/Actions/Predicates/ControllerActionDescriptorHttpGetPredicateWrapper.cs
@@ -3,7 +3,9 @@ using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Internal;
+using Mozart.Composition.AspNetCore.Mvc.Actions.Filters;
 using Mozart.Composition.AspNetCore.Mvc.Actions.Predicates.Abstractions;
+using Mozart.Composition.Core.Extensions;
 
 namespace Mozart.Composition.AspNetCore.Mvc.Actions.Predicates
 {
@@ -11,6 +13,11 @@ namespace Mozart.Composition.AspNetCore.Mvc.Actions.Predicates
     {
         public Func<ControllerActionDescriptor, bool> Predicate => x =>
         {
+            if (!x.ControllerTypeInfo.HasAttribute<MozartComposeModelAttribute>() && x.MethodInfo.HasAttribute<MozartComposeModelAttribute>())
+            {
+                return false;
+            }
+
             if (x.ActionConstraints == null || x.ActionConstraints.Any(ac =>
                     ac.GetType() == typeof(HttpMethodActionConstraint)))
             {

--- a/src/Mozart.Composition.AspNetCore.Mvc/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Mozart.Composition.AspNetCore.Mvc/DependencyInjection/ServiceCollectionExtensions.cs
@@ -51,12 +51,6 @@ namespace Mozart.Composition.AspNetCore.Mvc.DependencyInjection
             return serviceCollection;
         }
 
-        public static void AddMozartModelCompositionGlobally(this IServiceCollection serviceCollection)
-        {
-            // The result filter that orchestrates the composition of the result
-            serviceCollection.Configure<MvcOptions>(options => { options.Filters.Add<CompositionResultActionFilter>(); });
-        }
-
         private static void RegisterResultHandlerResolver(IServiceCollection serviceCollection)
         {
             serviceCollection.AddSingleton<IActionDescriptorReturnTypeProvider<ControllerActionDescriptor>, ControllerActionDescriptorReturnTypeProvider>();

--- a/src/Mozart.Composition.Core/Extensions/TypeExtensions.cs
+++ b/src/Mozart.Composition.Core/Extensions/TypeExtensions.cs
@@ -59,5 +59,15 @@ namespace Mozart.Composition.Core.Extensions
             var baseType = givenType.BaseType;
             return baseType != null && IsAssignableToGenericType(baseType, genericType);
         }
+
+        public static bool HasAttribute<TAttribute>(this Type memberType) where TAttribute : Attribute
+        {
+            return Attribute.GetCustomAttribute(memberType, typeof(TAttribute)) != null;
+        }
+
+        public static bool HasAttribute<TAttribute>(this MemberInfo memberInfo) where TAttribute : Attribute
+        {
+            return HasAttribute<TAttribute>(memberInfo.GetType());
+        }
     }
 }


### PR DESCRIPTION
Rationale here is that nobody is going to want this done globally.  If anyone does then they can do this in their Startup easily.