### PR TITLE
Extract composition logic from ASP.NET filter

### DIFF
--- a/demo/Mozart.Composition.AspNetCore.Mvc.Demo/Controllers/ProductAsyncController.cs
+++ b/demo/Mozart.Composition.AspNetCore.Mvc.Demo/Controllers/ProductAsyncController.cs
@@ -1,48 +1,81 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Mozart.Composition.AspNetCore.Mvc.Actions.Filters;
+using Microsoft.AspNetCore.Routing;
 using Mozart.Composition.AspNetCore.Mvc.Demo.Models;
+using Mozart.Composition.Core.Abstractions;
 
 namespace Mozart.Composition.AspNetCore.Mvc.Demo.Controllers
 {
     [Route("api/[controller]")]
     [ApiController]
-    [MozartComposeModel]
     public class ProductAsyncController : ControllerBase
     {
+        private readonly IMozartModelComposer<Product> _productModelComposer;
+
+        public ProductAsyncController(IMozartModelComposer<Product> productModelComposer)
+        {
+            _productModelComposer = productModelComposer ?? throw new ArgumentNullException(nameof(productModelComposer));
+        }
+
         // GET: api/<controller>/{id}/IActionResult
         [HttpGet]
         [ProducesResponseType(200, Type = typeof(Product))]
+        [ProducesResponseType(404)]
         [Route("{id}/IActionResult")]
         public async Task<IActionResult> GetProductIActionResult(int id)
         {
-            return Ok();
+            var result = await _productModelComposer.BuildCompositeModelAsync(HttpContext.GetRouteData().Values);
+
+            if (result == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(result);
         }
 
         // GET: api/<controller>/{id}/ActionResult
         [HttpGet]
         [ProducesResponseType(200, Type = typeof(Product))]
+        [ProducesResponseType(404)]
         [Route("{id}/ActionResult")]
         public async Task<ActionResult> GetProductActionResult(int id)
         {
-            return Ok();
+            var result = await _productModelComposer.BuildCompositeModelAsync(HttpContext.GetRouteData().Values);
+
+            if (result == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(result);
         }
 
 
         // GET: api/<controller>/{id}/ActionResultOfT
         [HttpGet]
         [Route("{id}/ActionResultOfT")]
-        public async Task<ActionResult<Product>> GetProductActionResultOfT()
+        public async Task<ActionResult<Product>> GetProductActionResultOfT(int id)
         {
-            return Ok();
+            var result = await _productModelComposer.BuildCompositeModelAsync(HttpContext.GetRouteData().Values);
+
+            if (result == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(result);
         }
 
         // GET: api/<controller>/ObjectResult
         [HttpGet]
         [Route("{id}/ObjectResult")]
-        public async Task<Product> GetObjectResult()
+        public async Task<Product> GetObjectResult(int id)
         {
-            return null;
+            var result = await _productModelComposer.BuildCompositeModelAsync(HttpContext.GetRouteData().Values);
+
+            return result;
         }
     }
 }

--- a/demo/Mozart.Composition.AspNetCore.Mvc.Demo/Controllers/ProductController.cs
+++ b/demo/Mozart.Composition.AspNetCore.Mvc.Demo/Controllers/ProductController.cs
@@ -7,23 +7,28 @@ namespace Mozart.Composition.AspNetCore.Mvc.Demo.Controllers
     [Route("api/[controller]")]
     [ApiController]
     [MozartComposeModel]
+
     public class ProductController : ControllerBase
     {
         // GET: api/<controller>/{id}/IActionResult
         [HttpGet]
         [ProducesResponseType(200, Type = typeof(Product))]
+        [ProducesResponseType(404)]
         [Route("{id}/IActionResult")]
         public IActionResult GetProductIActionResult(int id)
         {
+            // This result is intercepted by the MozartComposeModel attribute
             return Ok();
         }
 
         // GET: api/<controller>/{id}/ActionResult
         [HttpGet]
         [ProducesResponseType(200, Type = typeof(Product))]
+        [ProducesResponseType(404)]
         [Route("{id}/ActionResult")]
         public ActionResult GetProductActionResult(int id)
         {
+            // This result is intercepted by the MozartComposeModel attribute
             return Ok();
         }
 
@@ -32,6 +37,7 @@ namespace Mozart.Composition.AspNetCore.Mvc.Demo.Controllers
         [Route("{id}/ActionResultOfT")]
         public ActionResult<Product> GetProductActionResultOfT(int id)
         {
+            // This result is intercepted by the MozartComposeModel attribute
             return Ok();
         }
 
@@ -40,6 +46,7 @@ namespace Mozart.Composition.AspNetCore.Mvc.Demo.Controllers
         [Route("{id}/ObjectResult")]
         public Product GetObjectResult(int id)
         {
+            // This result is intercepted by the MozartComposeModel attribute
             return null;
         }
     }

--- a/demo/Mozart.Composition.ModelComposition.Details/Composers/ProductPriceComposer.cs
+++ b/demo/Mozart.Composition.ModelComposition.Details/Composers/ProductPriceComposer.cs
@@ -7,7 +7,7 @@ namespace Mozart.Composition.ModelComposition.Details.Composers
 {
     public class ProductPriceComposer : ComposeModel<ProductDetails>
     {
-        public override async Task<ProductDetails> ComposeOfT(IDictionary<string, object> parameters)
+        public override async Task<ProductDetails> ComposeOfTAsync(IDictionary<string, object> parameters)
         {
             return new ProductDetails
             {

--- a/demo/Mozart.Composition.ModelComposition.Pricing/Composers/ProductPriceComposer.cs
+++ b/demo/Mozart.Composition.ModelComposition.Pricing/Composers/ProductPriceComposer.cs
@@ -7,7 +7,7 @@ namespace Mozart.Composition.ModelComposition.Pricing.Composers
 {
     public class ProductPriceComposer : ComposeModel<ProductPrice>
     {
-        public override async Task<ProductPrice> ComposeOfT(IDictionary<string, object> parameters)
+        public override async Task<ProductPrice> ComposeOfTAsync(IDictionary<string, object> parameters)
         {
             return new ProductPrice
             {

--- a/demo/Mozart.Composition.ModelComposition.Stock/Composers/ProductStockComposer.cs
+++ b/demo/Mozart.Composition.ModelComposition.Stock/Composers/ProductStockComposer.cs
@@ -17,7 +17,7 @@ namespace Mozart.Composition.ModelComposition.Stock.Composers
             _productStockService = productStockService ?? throw new ArgumentNullException(nameof(productStockService));
         }
 
-        public override async Task<ProductStock> ComposeOfT(IDictionary<string, object> parameters)
+        public override async Task<ProductStock> ComposeOfTAsync(IDictionary<string, object> parameters)
         {
             var id = parameters.GetId();
 

--- a/src/Mozart.Composition.AspNetCore.Mvc.UnitTests/Mozart.Composition.AspNetCore.Mvc.UnitTests.csproj
+++ b/src/Mozart.Composition.AspNetCore.Mvc.UnitTests/Mozart.Composition.AspNetCore.Mvc.UnitTests.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Mozart.Composition.AspNetCore.Mvc/Actions/Filters/CompositionResultActionFilter.cs
+++ b/src/Mozart.Composition.AspNetCore.Mvc/Actions/Filters/CompositionResultActionFilter.cs
@@ -12,7 +12,7 @@ namespace Mozart.Composition.AspNetCore.Mvc.Actions.Filters
     {
         private readonly ICachedServiceResolver<string, IHandleResult> _resultHandlerResolver;
 
-        internal CompositionResultActionFilter(ICachedServiceResolver<string, IHandleResult> resultHandlerResolver)
+        public CompositionResultActionFilter(ICachedServiceResolver<string, IHandleResult> resultHandlerResolver)
         {
             _resultHandlerResolver = resultHandlerResolver;        
         }
@@ -35,7 +35,7 @@ namespace Mozart.Composition.AspNetCore.Mvc.Actions.Filters
                 }
                 else
                 {
-                    var result = await handler.Handle(context.HttpContext);
+                    var result = await handler.HandleAsync(context.HttpContext);
                     ApplyResultToContext(resultContext, result);
                 }
             }

--- a/src/Mozart.Composition.AspNetCore.Mvc/Actions/Predicates/ControllerActionDescriptorHttpGetPredicateWrapper.cs
+++ b/src/Mozart.Composition.AspNetCore.Mvc/Actions/Predicates/ControllerActionDescriptorHttpGetPredicateWrapper.cs
@@ -13,7 +13,7 @@ namespace Mozart.Composition.AspNetCore.Mvc.Actions.Predicates
     {
         public Func<ControllerActionDescriptor, bool> Predicate => x =>
         {
-            if (!x.ControllerTypeInfo.HasAttribute<MozartComposeModelAttribute>() && x.MethodInfo.HasAttribute<MozartComposeModelAttribute>())
+            if (!x.ControllerTypeInfo.HasAttribute<MozartComposeModelAttribute>() && x.MethodInfo.GetType().HasAttribute<MozartComposeModelAttribute>())
             {
                 return false;
             }

--- a/src/Mozart.Composition.AspNetCore.Mvc/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Mozart.Composition.AspNetCore.Mvc/DependencyInjection/ServiceCollectionExtensions.cs
@@ -2,12 +2,10 @@
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.Extensions.DependencyInjection;
 using Mozart.Composition.AspNetCore.Mvc.Actions;
 using Mozart.Composition.AspNetCore.Mvc.Actions.Abstractions;
-using Mozart.Composition.AspNetCore.Mvc.Actions.Filters;
 using Mozart.Composition.AspNetCore.Mvc.Actions.Predicates;
 using Mozart.Composition.AspNetCore.Mvc.Actions.Predicates.Abstractions;
 using Mozart.Composition.AspNetCore.Mvc.Actions.ReturnTypes;
@@ -16,6 +14,7 @@ using Mozart.Composition.AspNetCore.Mvc.Actions.ReturnTypes.Strategies;
 using Mozart.Composition.AspNetCore.Mvc.Actions.ReturnTypes.Strategies.Abstractions;
 using Mozart.Composition.AspNetCore.Mvc.Results;
 using Mozart.Composition.AspNetCore.Mvc.Results.Abstractions;
+using Mozart.Composition.Core;
 using Mozart.Composition.Core.Abstractions;
 using Mozart.Composition.Core.DependencyInjection;
 using Mozart.Composition.Core.Extensions;
@@ -31,8 +30,11 @@ namespace Mozart.Composition.AspNetCore.Mvc.DependencyInjection
             // Register the IComposeModel<> types
             var composeModelTypes = serviceCollection.AddMozartModelComposition(fileNames);
 
-            // Register a default CompositionResultHandler to handle our composite view models 
-            serviceCollection.AddSingleton(typeof(IHandleResult<>), typeof(CompositionResultHandler<>));
+            // Register a default underlying IMozartModelComposer
+            serviceCollection.AddSingleton(typeof(IMozartModelComposer<>), typeof(MozartAggregateModelComposer<>));
+
+            // Register a default CompositionResultHandler wrap the default IMozartModelComposers for ASP.NET 
+            serviceCollection.AddSingleton(typeof(IHandleResult<>), typeof(CompositionResultHandler<>));        
 
             // Register an EntireResultHandler for each IComposeModel<T> - this allows each handler to be invoked directly if we only want to return a single property
             foreach (var type in composeModelTypes)

--- a/src/Mozart.Composition.AspNetCore.Mvc/Mozart.Composition.AspNetCore.Mvc.csproj
+++ b/src/Mozart.Composition.AspNetCore.Mvc/Mozart.Composition.AspNetCore.Mvc.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Mozart.Composition.AspNetCore.Mvc/Results/Abstractions/CompositionResultHandlerBase.cs
+++ b/src/Mozart.Composition.AspNetCore.Mvc/Results/Abstractions/CompositionResultHandlerBase.cs
@@ -5,11 +5,11 @@ namespace Mozart.Composition.AspNetCore.Mvc.Results.Abstractions
 {
     public abstract class CompositionResultHandlerBase<T> : IHandleResult<T> where T : class, new()
     {
-        public async Task<(object Model, int StatusCode)> Handle(HttpContext context)
+        public async Task<(object Model, int StatusCode)> HandleAsync(HttpContext context)
         {
-            return await HandleOfT(context);
+            return await HandleOfTAsync(context);
         }
 
-        public abstract Task<(T Model, int StatusCode)> HandleOfT(HttpContext context);
+        public abstract Task<(T Model, int StatusCode)> HandleOfTAsync(HttpContext context);
     }
 }

--- a/src/Mozart.Composition.AspNetCore.Mvc/Results/Abstractions/EntireResultHandlerBase.cs
+++ b/src/Mozart.Composition.AspNetCore.Mvc/Results/Abstractions/EntireResultHandlerBase.cs
@@ -5,11 +5,11 @@ namespace Mozart.Composition.AspNetCore.Mvc.Results.Abstractions
 {
     public abstract class EntireResultHandlerBase<T> : IHandleResult<T> where T : class
     {
-        public async Task<(object Model, int StatusCode)> Handle(HttpContext context)
+        public async Task<(object Model, int StatusCode)> HandleAsync(HttpContext context)
         {
-            return await HandleOfT(context);
+            return await HandleOfTAsync(context);
         }
 
-        public abstract Task<(T Model, int StatusCode)> HandleOfT(HttpContext context);
+        public abstract Task<(T Model, int StatusCode)> HandleOfTAsync(HttpContext context);
     }
 }

--- a/src/Mozart.Composition.AspNetCore.Mvc/Results/Abstractions/IHandleResult.cs
+++ b/src/Mozart.Composition.AspNetCore.Mvc/Results/Abstractions/IHandleResult.cs
@@ -5,6 +5,6 @@ namespace Mozart.Composition.AspNetCore.Mvc.Results.Abstractions
 {
     public interface IHandleResult
     {
-        Task<(object Model, int StatusCode)> Handle(HttpContext context);
+        Task<(object Model, int StatusCode)> HandleAsync(HttpContext context);
     }
 }

--- a/src/Mozart.Composition.AspNetCore.Mvc/Results/Abstractions/IHandleResultOfT.cs
+++ b/src/Mozart.Composition.AspNetCore.Mvc/Results/Abstractions/IHandleResultOfT.cs
@@ -5,6 +5,6 @@ namespace Mozart.Composition.AspNetCore.Mvc.Results.Abstractions
 {
     public interface IHandleResult<T> : IHandleResult where T : class
     {
-        Task<(T Model, int StatusCode)> HandleOfT(HttpContext context);
+        Task<(T Model, int StatusCode)> HandleOfTAsync(HttpContext context);
     }
 }

--- a/src/Mozart.Composition.AspNetCore.Mvc/Results/CompositionResultHandler.cs
+++ b/src/Mozart.Composition.AspNetCore.Mvc/Results/CompositionResultHandler.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -12,50 +9,20 @@ namespace Mozart.Composition.AspNetCore.Mvc.Results
 {
     public class CompositionResultHandler<TModel> : CompositionResultHandlerBase<TModel> where TModel : class, new()
     {
-        private readonly ICachedServiceResolver<Type, IComposeModel> _modelComposerResolver;
-        private readonly IEnumerable<PropertyInfo> _cachedPropertyInfos;
+        private readonly IMozartModelComposer<TModel> _modelComposer;
 
-        public CompositionResultHandler(ICachedServiceResolver<Type, IComposeModel> modelComposerResolver)
+        public CompositionResultHandler(IMozartModelComposer<TModel> modelComposer)
         {
-            // The custom resolver that will get our view model composition services by property type
-            _modelComposerResolver = modelComposerResolver;
-
-            // Do the expensive reflection piece when this class is instantiated (as a singleton), ideally before serving requests
-            _cachedPropertyInfos = typeof(TModel).GetProperties().Where(x => x.CanRead && x.CanWrite);
+            // The custom composer that will orchestrate the composition
+            _modelComposer = modelComposer ?? throw new ArgumentNullException(nameof(modelComposer));
         }
 
-        public override async Task<(TModel Model, int StatusCode)> HandleOfT(HttpContext context)
+        public override async Task<(TModel Model, int StatusCode)> HandleOfTAsync(HttpContext context)
         {
-            var result = new TModel();
-
-            var pending = new List<Task>();
-
-            foreach (var cachedPropertyInfo in _cachedPropertyInfos)
-            {
-                // Find a IComposeModel that can service this particular property type
-                if (!_modelComposerResolver.TryResolve(cachedPropertyInfo.PropertyType, out var composer))
-                {
-                    //Log a warning 
-                    continue;
-                }
-
-                pending.Add(AssignPropertyFromComposer(composer, cachedPropertyInfo, result, context.GetRouteData().Values));
-            }
-
-            if (pending.Count == 0)
-            {
-                return (null, StatusCodes.Status404NotFound);
-            }
-
-            await Task.WhenAll(pending);
-            return (result, StatusCodes.Status200OK);
-        }
-
-        private static async Task AssignPropertyFromComposer(IComposeModel composer, PropertyInfo cachedPropertyInfo,
-            TModel result, IDictionary<string, object> routeParameters)
-        {
-            var propertyValue = await composer.Compose(routeParameters);
-            cachedPropertyInfo.SetValue(result, propertyValue);
+            // This method simply wraps the behaviour of IMozartModelComposer and enhances with status codes for ASP.NET
+            var result = await _modelComposer.BuildCompositeModelAsync(context.GetRouteData().Values);
+            var statusCode = result != null ? StatusCodes.Status200OK : StatusCodes.Status404NotFound;
+            return (result, statusCode);
         }
     }
 }

--- a/src/Mozart.Composition.AspNetCore.Mvc/Results/EntireResultHandler.cs
+++ b/src/Mozart.Composition.AspNetCore.Mvc/Results/EntireResultHandler.cs
@@ -17,7 +17,7 @@ namespace Mozart.Composition.AspNetCore.Mvc.Results
             _modelCompositionCachedServiceResolver = modelCompositionCachedServiceResolver;
         }
 
-        public override async Task<(T Model, int StatusCode)> HandleOfT(HttpContext context)
+        public override async Task<(T Model, int StatusCode)> HandleOfTAsync(HttpContext context)
         {
             // Leverage the IComposeModel implementation to create an entire result
             if (!_modelCompositionCachedServiceResolver.TryResolve(typeof(T), out var composeModel))
@@ -25,7 +25,7 @@ namespace Mozart.Composition.AspNetCore.Mvc.Results
                 return (null, StatusCodes.Status404NotFound);
             }
 
-            var result = (T) await composeModel.Compose(context.GetRouteData().Values);
+            var result = (T) await composeModel.ComposeAsync(context.GetRouteData().Values);
             return (result, StatusCodes.Status200OK);
         }
     }

--- a/src/Mozart.Composition.Core.UnitTests/Core/MozartAggregateModelComposerShould.cs
+++ b/src/Mozart.Composition.Core.UnitTests/Core/MozartAggregateModelComposerShould.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Moq;
+using Mozart.Composition.Core.Abstractions;
+using Mozart.Composition.Core.UnitTests.Fakes;
+using Shouldly;
+using Xunit;
+
+namespace Mozart.Composition.Core.UnitTests.Core
+{
+    public class MozartAggregateModelComposerShould
+    {
+        private readonly Mock<IComposeModel<FakeDomainClass1>> _mockFirstComposer;
+        private readonly Mock<IComposeModel<FakeDomainClass2>> _mockSecondComposer;
+
+        public MozartAggregateModelComposerShould()
+        {
+            _mockFirstComposer = new Mock<IComposeModel<FakeDomainClass1>>();
+            _mockSecondComposer = new Mock<IComposeModel<FakeDomainClass2>>();
+        }
+
+        [Fact]
+        public async Task CallComposeAsyncOnEachIComposeModelThatIsResolved()
+        {
+            // Arrange
+            var suppliedDictionary = new Dictionary<string, object>();
+
+            _mockFirstComposer.Setup(x => x.ComposeAsync(suppliedDictionary))
+                .ReturnsAsync(new FakeDomainClass1());
+
+            _mockSecondComposer.Setup(x => x.ComposeAsync(suppliedDictionary))
+                .ReturnsAsync(new FakeDomainClass2());
+
+            var mozartAggregateModelComposer = GetMozartAggregateModelComposer(new List<IComposeModel>
+                {_mockFirstComposer.Object, _mockSecondComposer.Object});
+
+            // Act
+            await mozartAggregateModelComposer.BuildCompositeModelAsync(suppliedDictionary);
+
+            // Assert
+            _mockFirstComposer.Verify(x => x.ComposeAsync(suppliedDictionary), Times.Once);
+            _mockSecondComposer.Verify(x => x.ComposeAsync(suppliedDictionary), Times.Once);
+        }
+
+        [Fact]
+        public async Task NotCallComposeAsyncOnAnyIComposeModelThatIsNotRequiredForCompositeModel()
+        {
+            // Arrange
+            var suppliedDictionary = new Dictionary<string, object>();
+
+            _mockFirstComposer.Setup(x => x.ComposeAsync(suppliedDictionary))
+                .ReturnsAsync(new FakeDomainClass1());
+
+            _mockSecondComposer.Setup(x => x.ComposeAsync(suppliedDictionary))
+                .ReturnsAsync(new FakeDomainClass2());
+
+            var mockUnusedComposer = new Mock<IComposeModel<string>>();
+
+            var mozartAggregateModelComposer = GetMozartAggregateModelComposer(new List<IComposeModel>
+                {_mockFirstComposer.Object, _mockSecondComposer.Object, mockUnusedComposer.Object});
+
+            // Act
+            await mozartAggregateModelComposer.BuildCompositeModelAsync(suppliedDictionary);
+
+            // Assert
+            mockUnusedComposer.Verify(x => x.ComposeAsync(suppliedDictionary), Times.Never);
+        }
+
+        [Fact]
+        public async Task ReturnAFullyConstructedCompositeModelWhenAllPropertyIComposeModelsCanBeResolved()
+        {
+            // Arrange
+            var suppliedDictionary = new Dictionary<string, object>();
+            var expectedFirstDomainObject = new FakeDomainClass1();
+            var expectedSecondDomainObject = new FakeDomainClass2();
+
+            _mockFirstComposer.Setup(x => x.ComposeAsync(suppliedDictionary))
+                .ReturnsAsync(expectedFirstDomainObject);
+
+            _mockSecondComposer.Setup(x => x.ComposeAsync(suppliedDictionary))
+                .ReturnsAsync(expectedSecondDomainObject);
+
+            var mozartAggregateModelComposer = GetMozartAggregateModelComposer(new List<IComposeModel>
+                {_mockFirstComposer.Object, _mockSecondComposer.Object});
+
+            // Act
+            var compositeModel = await mozartAggregateModelComposer.BuildCompositeModelAsync(suppliedDictionary);
+
+            // Assert
+            compositeModel.ShouldNotBeNull();
+            compositeModel.Domain1.ShouldBe(expectedFirstDomainObject);
+            compositeModel.Domain2.ShouldBe(expectedSecondDomainObject);
+        }
+
+        [Fact]
+        public async Task ReturnAPartiallyConstructedCompositeModelWhenSomePropertyIComposeModelsCanBeResolved()
+        {
+            // Arrange
+            var suppliedDictionary = new Dictionary<string, object>();
+            var expectedFirstDomainObject = new FakeDomainClass1();
+
+            _mockFirstComposer.Setup(x => x.ComposeAsync(suppliedDictionary))
+                .ReturnsAsync(expectedFirstDomainObject);
+
+            var mozartAggregateModelComposer = GetMozartAggregateModelComposer(new List<IComposeModel>
+                {_mockFirstComposer.Object});
+
+            // Act
+            var compositeModel = await mozartAggregateModelComposer.BuildCompositeModelAsync(suppliedDictionary);
+
+            // Assert
+            compositeModel.ShouldNotBeNull();
+            compositeModel.Domain1.ShouldBe(expectedFirstDomainObject);
+            compositeModel.Domain2.ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task ReturnDefaultIfNoComposeModelsCanBeResolved()
+        {
+            // Arrange
+            var suppliedDictionary = new Dictionary<string, object>();
+
+            var mozartAggregateModelComposer = GetMozartAggregateModelComposer(new List<IComposeModel>());
+
+            // Act
+            var compositeModel = await mozartAggregateModelComposer.BuildCompositeModelAsync(suppliedDictionary);
+
+            // Assert
+            compositeModel.ShouldBeNull();
+        }
+
+        private MozartAggregateModelComposer<FakeCompositeModel> GetMozartAggregateModelComposer(IEnumerable<IComposeModel> composeModels)
+        {
+            var modelComposerResolver = new ComposeModelResolver(composeModels);
+
+            return new MozartAggregateModelComposer<FakeCompositeModel>(modelComposerResolver);
+        }
+    }
+}

--- a/src/Mozart.Composition.Core.UnitTests/Fakes/FakeCompositeModel.cs
+++ b/src/Mozart.Composition.Core.UnitTests/Fakes/FakeCompositeModel.cs
@@ -1,0 +1,16 @@
+﻿namespace Mozart.Composition.Core.UnitTests.Fakes
+{
+    public class FakeCompositeModel
+    {
+        public FakeDomainClass1 Domain1 { get; set; }
+        public FakeDomainClass2 Domain2 { get; set; }
+    }
+
+    public class FakeDomainClass1
+    {
+    }
+
+    public class FakeDomainClass2
+    {
+    }
+}

--- a/src/Mozart.Composition.Core.UnitTests/Mozart.Composition.Core.UnitTests.csproj
+++ b/src/Mozart.Composition.Core.UnitTests/Mozart.Composition.Core.UnitTests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="Shouldly" Version="3.0.2" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Mozart.Composition.Core\Mozart.Composition.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Mozart.Composition.Core/Core/Abstractions/ComposeModel.cs
+++ b/src/Mozart.Composition.Core/Core/Abstractions/ComposeModel.cs
@@ -5,11 +5,11 @@ namespace Mozart.Composition.Core.Abstractions
 {
     public abstract class ComposeModel<T> : IComposeModel<T>
     {
-        public async Task<object> Compose(IDictionary<string, object> parameters)
+        public async Task<object> ComposeAsync(IDictionary<string, object> parameters)
         {
-            return await ComposeOfT(parameters);
+            return await ComposeOfTAsync(parameters);
         }
 
-        public abstract Task<T> ComposeOfT(IDictionary<string, object> parameters);
+        public abstract Task<T> ComposeOfTAsync(IDictionary<string, object> parameters);
     }
 }

--- a/src/Mozart.Composition.Core/Core/Abstractions/IComposeModel.cs
+++ b/src/Mozart.Composition.Core/Core/Abstractions/IComposeModel.cs
@@ -5,6 +5,6 @@ namespace Mozart.Composition.Core.Abstractions
 {
     public interface IComposeModel
     { 
-        Task<object> Compose(IDictionary<string, object> parameters);
+        Task<object> ComposeAsync(IDictionary<string, object> parameters);
     }
 }

--- a/src/Mozart.Composition.Core/Core/Abstractions/IComposeViewModelOfT.cs
+++ b/src/Mozart.Composition.Core/Core/Abstractions/IComposeViewModelOfT.cs
@@ -5,6 +5,6 @@ namespace Mozart.Composition.Core.Abstractions
 {
     public interface IComposeModel<T> : IComposeModel
     {
-        Task<T> ComposeOfT(IDictionary<string, object> parameters);
+        Task<T> ComposeOfTAsync(IDictionary<string, object> parameters);
     }
 }

--- a/src/Mozart.Composition.Core/Core/Abstractions/IMozartModelComposer.cs
+++ b/src/Mozart.Composition.Core/Core/Abstractions/IMozartModelComposer.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Mozart.Composition.Core.Abstractions
+{
+    public interface IMozartModelComposer<TModel> where TModel : class, new()
+    {
+        Task<TModel> BuildCompositeModelAsync(IDictionary<string, object> parameters);
+    }
+}

--- a/src/Mozart.Composition.Core/Core/MozartAggregateModelComposer.cs
+++ b/src/Mozart.Composition.Core/Core/MozartAggregateModelComposer.cs
@@ -41,7 +41,7 @@ namespace Mozart.Composition.Core
 
             if (pendingTasks.Count == 0)
             {
-                return null;
+                return default;
             }
 
             await Task.WhenAll(pendingTasks);

--- a/src/Mozart.Composition.Core/Core/MozartAggregateModelComposer.cs
+++ b/src/Mozart.Composition.Core/Core/MozartAggregateModelComposer.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Mozart.Composition.Core.Abstractions;
+
+namespace Mozart.Composition.Core
+{
+    public class MozartAggregateModelComposer<TModel> : IMozartModelComposer<TModel> where TModel: class, new ()
+    {
+        private readonly ICachedServiceResolver<Type, IComposeModel> _modelComposerResolver;
+        private readonly IEnumerable<PropertyInfo> _cachedPropertyInfos;
+
+        public MozartAggregateModelComposer(ICachedServiceResolver<Type, IComposeModel> modelComposerResolver)
+        {
+            // The custom resolver that will get our view model composition services by property type
+            _modelComposerResolver = modelComposerResolver;
+
+            // Do the expensive reflection piece when this class is instantiated (as a singleton), ideally before serving requests
+            _cachedPropertyInfos = typeof(TModel).GetProperties().Where(x => x.CanRead && x.CanWrite);
+        }
+
+        public async Task<TModel> BuildCompositeModelAsync(IDictionary<string, object> parameters)
+        {           
+            var result = new TModel();
+
+            var pendingTasks = new List<Task>();
+
+            foreach (var cachedPropertyInfo in _cachedPropertyInfos)
+            {
+                // Find an IComposeModel that can service this particular property type
+                if (!_modelComposerResolver.TryResolve(cachedPropertyInfo.PropertyType, out var composer))
+                {
+                    //Log a warning 
+                    continue;
+                }
+
+                pendingTasks.Add(AssignPropertyFromComposer(composer, cachedPropertyInfo, result, parameters));
+            }
+
+            if (pendingTasks.Count == 0)
+            {
+                return null;
+            }
+
+            await Task.WhenAll(pendingTasks);
+            return result;
+        }
+
+        private static async Task AssignPropertyFromComposer(IComposeModel composer, PropertyInfo cachedPropertyInfo,
+            TModel result, IDictionary<string, object> routeParameters)
+        {
+            var propertyValue = await composer.ComposeAsync(routeParameters);
+            cachedPropertyInfo.SetValue(result, propertyValue);
+        }
+    }
+}

--- a/src/Mozart.Composition.Core/Extensions/TypeExtensions.cs
+++ b/src/Mozart.Composition.Core/Extensions/TypeExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 
@@ -65,9 +66,5 @@ namespace Mozart.Composition.Core.Extensions
             return Attribute.GetCustomAttribute(memberType, typeof(TAttribute)) != null;
         }
 
-        public static bool HasAttribute<TAttribute>(this MemberInfo memberInfo) where TAttribute : Attribute
-        {
-            return HasAttribute<TAttribute>(memberInfo.GetType());
-        }
     }
 }

--- a/src/Mozart.Composition.Core/Mozart.Composition.Core.csproj
+++ b/src/Mozart.Composition.Core/Mozart.Composition.Core.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Mozart.Composition.sln
+++ b/src/Mozart.Composition.sln
@@ -5,11 +5,13 @@ VisualStudioVersion = 15.0.28010.2026
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mozart.Composition.Core", "Mozart.Composition.Core\Mozart.Composition.Core.csproj", "{5FFD9864-12ED-4469-9C8F-7B3E7D785E96}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mozart.Composition.AspNetCore.Mvc", "Mozart.Composition.AspNetCore.Mvc\Mozart.Composition.AspNetCore.Mvc.csproj", "{EB37B2E4-9E8A-4651-B339-3774C7954463}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mozart.Composition.AspNetCore.Mvc", "Mozart.Composition.AspNetCore.Mvc\Mozart.Composition.AspNetCore.Mvc.csproj", "{EB37B2E4-9E8A-4651-B339-3774C7954463}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Unit Tests", "Unit Tests", "{46CD513F-B5BD-42D0-9AB8-DD8CFE9AA435}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mozart.Composition.AspNetCore.Mvc.UnitTests", "Mozart.Composition.AspNetCore.Mvc.UnitTests\Mozart.Composition.AspNetCore.Mvc.UnitTests.csproj", "{D3A2ED38-AB6C-4F32-9794-4C6A7514B21F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mozart.Composition.AspNetCore.Mvc.UnitTests", "Mozart.Composition.AspNetCore.Mvc.UnitTests\Mozart.Composition.AspNetCore.Mvc.UnitTests.csproj", "{D3A2ED38-AB6C-4F32-9794-4C6A7514B21F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mozart.Composition.Core.UnitTests", "Mozart.Composition.Core.UnitTests\Mozart.Composition.Core.UnitTests.csproj", "{371103CE-88A6-45E1-A120-DC9F471F8864}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -29,12 +31,17 @@ Global
 		{D3A2ED38-AB6C-4F32-9794-4C6A7514B21F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D3A2ED38-AB6C-4F32-9794-4C6A7514B21F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D3A2ED38-AB6C-4F32-9794-4C6A7514B21F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{371103CE-88A6-45E1-A120-DC9F471F8864}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{371103CE-88A6-45E1-A120-DC9F471F8864}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{371103CE-88A6-45E1-A120-DC9F471F8864}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{371103CE-88A6-45E1-A120-DC9F471F8864}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{D3A2ED38-AB6C-4F32-9794-4C6A7514B21F} = {46CD513F-B5BD-42D0-9AB8-DD8CFE9AA435}
+		{371103CE-88A6-45E1-A120-DC9F471F8864} = {46CD513F-B5BD-42D0-9AB8-DD8CFE9AA435}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {97243AAF-F02D-4A7D-95E9-D336DAC97F03}


### PR DESCRIPTION
Create new injectable `IMozartModelComposer<TModel>` that the existing filter will leverage.

This allows a controller to have this injected to give developers the option of using AOP (which may seem a bit "magic") or a more explicit call to a Mozart service.